### PR TITLE
ci: add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: ruby

--- a/lib/sorbet-schema.rb
+++ b/lib/sorbet-schema.rb
@@ -9,6 +9,7 @@ require "zeitwerk"
 loader = Zeitwerk::Loader.new
 loader.push_dir(__dir__.to_s)
 loader.ignore(__FILE__)
+loader.ignore("#{__dir__}/sorbet-schema/version.rb")
 loader.inflector.inflect(
   "json_serializer" => "JSONSerializer"
 )

--- a/lib/sorbet-schema/version.rb
+++ b/lib/sorbet-schema/version.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module SorbetSchema
+  VERSION = "0.1.0"
+end

--- a/sorbet-schema.gemspec
+++ b/sorbet-schema.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "lib/sorbet-schema/version"
+
 Gem::Specification.new do |spec|
   spec.name = "sorbet-schema"
-  spec.version = "0.1.0"
+  spec.version = SorbetSchema::VERSION
   spec.authors = ["Max VelDink"]
   spec.email = ["maxveldink@gmail.com"]
 


### PR DESCRIPTION
[release-please](https://github.com/googleapis/release-please) automates release PR and changelog management based on conventional commits. Here, we switch to using a `version.rb` file since that is required for release-please to run. We also set up the workflow and repository secret.