### PR TITLE
feat: Create schema extension on `T::Struct`

### DIFF
--- a/lib/sorbet-schema.rb
+++ b/lib/sorbet-schema.rb
@@ -3,6 +3,7 @@
 
 require "sorbet-runtime"
 require "sorbet-result"
+require "sorbet-struct-comparable"
 
 # We can't use `Loader.for_gem` here as we've unconventionally named the root file.
 require "zeitwerk"

--- a/lib/sorbet-schema.rb
+++ b/lib/sorbet-schema.rb
@@ -10,7 +10,7 @@ require "zeitwerk"
 loader = Zeitwerk::Loader.new
 loader.push_dir(__dir__.to_s)
 loader.ignore(__FILE__)
-loader.ignore("#{__dir__}/sorbet-schema/version.rb")
+loader.ignore("#{__dir__}/sorbet-schema/*.rb")
 loader.inflector.inflect(
   "json_serializer" => "JSONSerializer"
 )

--- a/lib/sorbet-schema/struct_ext.rb
+++ b/lib/sorbet-schema/struct_ext.rb
@@ -1,0 +1,17 @@
+# typed: strict
+
+module T
+  class Struct
+    extend T::Sig
+
+    sig { returns(Typed::Schema) }
+    def self.create_schema
+      Typed::Schema.new(
+        target: self,
+        fields: props.map do |name, properties|
+          Typed::Field.new(name:, type: properties[:type], required: !properties[:fully_optional])
+        end
+      )
+    end
+  end
+end

--- a/lib/typed/schema.rb
+++ b/lib/typed/schema.rb
@@ -4,6 +4,8 @@ module Typed
   class Schema < T::Struct
     extend T::Sig
 
+    include T::Struct::ActsAsComparable
+
     const :fields, T::Array[Field], default: []
     const :target, T.class_of(T::Struct)
 

--- a/test/struct_ext_test.rb
+++ b/test/struct_ext_test.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+require "sorbet-schema/struct_ext"
+
+class StructExtTest < Minitest::Test
+  def test_create_schema_is_available
+    assert_equal(PersonSchema, Person.create_schema)
+  end
+end

--- a/test/support/structs/person.rb
+++ b/test/support/structs/person.rb
@@ -1,7 +1,5 @@
 # typed: true
 
-require "sorbet-struct-comparable"
-
 class Person < T::Struct
   include T::Struct::ActsAsComparable
 


### PR DESCRIPTION
- Adds a `.create_schema` convenience methods on `T::Struct`s for generating schemas from them.

This is not autoloaded, it will need to be specifically required via `sorbet-schema/struct_ext.rb`