### PR TITLE
fix: default value set to true causes undefined method [] error

### DIFF
--- a/lib/typed/serializer.rb
+++ b/lib/typed/serializer.rb
@@ -35,8 +35,8 @@ module Typed
       results = schema.fields.map do |field|
         value = creation_params.fetch(field.name, nil)
 
-        if value.nil? && field.default
-          Success.new(Validations::ValidatedValue.new(field.default))
+        if value.nil? && !field.default.nil?
+          Success.new(Validations::ValidatedValue.new(name: field.name, value: field.default))
         elsif value.nil? || field.works_with?(value)
           field.validate(value)
         else

--- a/test/typed/hash_serializer_test.rb
+++ b/test/typed/hash_serializer_test.rb
@@ -1,6 +1,18 @@
 # typed: true
 
 class HashSerializerTest < Minitest::Test
+  class StructWithBooleanDefaultSetToTrue < T::Struct
+    include ActsAsComparable
+
+    const :tired, T::Boolean, default: true
+  end
+
+  class StructWithBooleanDefaultSetToFalse < T::Struct
+    include ActsAsComparable
+
+    const :tired, T::Boolean, default: false
+  end
+
   def setup
     @serializer = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(Person))
   end
@@ -107,6 +119,22 @@ class HashSerializerTest < Minitest::Test
 
     assert_success(result)
     assert_payload(ALEX_PERSON, result)
+  end
+
+  def test_it_can_deserialize_with_default_value_boolean_true
+    serializer = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(StructWithBooleanDefaultSetToTrue))
+    result = serializer.deserialize({})
+
+    assert_success(result)
+    assert_payload(StructWithBooleanDefaultSetToTrue.new(tired: true), result)
+  end
+
+  def test_it_can_deserialize_with_default_value_boolean_false
+    serializer = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(StructWithBooleanDefaultSetToFalse))
+    result = serializer.deserialize({})
+
+    assert_success(result)
+    assert_payload(StructWithBooleanDefaultSetToFalse.new(tired: false), result)
   end
 
   def test_it_reports_validation_errors_on_deserialize


### PR DESCRIPTION
There was a bug hidden by another partial bug. The hidden bug is [here](https://github.com/maxveldink/sorbet-schema/compare/antoine.bux_fix_for_default?expand=1#diff-d5e0d8635c53ddbccb9ab19dcf9cca7c1ef00026321ae937753dddb28b571aadL39) and it's just that it needs kwargs name and value. The bug that hid it was that the `field.default` check in the [conditional](https://github.com/maxveldink/sorbet-schema/compare/antoine.bux_fix_for_default?expand=1#diff-d5e0d8635c53ddbccb9ab19dcf9cca7c1ef00026321ae937753dddb28b571aadL38) `if value.nil? && field.default` will return false when the default value is false and it just so happened to be that our test struct defaults to false so line 39 was never tested.