### PR TITLE
refactor!: Replace deeply_nested_hash with options passing in struct ext

### DIFF
--- a/lib/sorbet-schema/serialize_value.rb
+++ b/lib/sorbet-schema/serialize_value.rb
@@ -10,7 +10,7 @@ class SerializeValue
     elsif value.is_a?(Array)
       value.map { |item| serialize(item) }
     elsif value.is_a?(T::Struct)
-      value.serialize_to(:deeply_nested_hash).payload_or(value)
+      value.serialize_to(:hash, options: {should_serialize_values: true}).payload_or(value)
     elsif value.respond_to?(:serialize)
       value.serialize
     else

--- a/lib/sorbet-schema/t/struct.rb
+++ b/lib/sorbet-schema/t/struct.rb
@@ -12,13 +12,11 @@ module T
         Typed::Schema.from_struct(self)
       end
 
-      sig { params(type: Symbol).returns(Typed::Serializer[T.untyped, T.untyped]) }
-      def serializer(type)
+      sig { params(type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Serializer[T.untyped, T.untyped]) }
+      def serializer(type, options: {})
         case type
-        when :deeply_nested_hash
-          Typed::HashSerializer.new(schema:, should_serialize_values: true)
         when :hash
-          Typed::HashSerializer.new(schema:)
+          Typed::HashSerializer.new(**T.unsafe({schema:, **options}))
         when :json
           Typed::JSONSerializer.new(schema:)
         else
@@ -26,15 +24,15 @@ module T
         end
       end
 
-      sig { params(serializer_type: Symbol, source: T.untyped).returns(Typed::Serializer::DeserializeResult) }
-      def deserialize_from(serializer_type, source)
-        serializer(serializer_type).deserialize(source)
+      sig { params(serializer_type: Symbol, source: T.untyped, options: T::Hash[Symbol, T.untyped]).returns(Typed::Serializer::DeserializeResult) }
+      def deserialize_from(serializer_type, source, options: {})
+        serializer(serializer_type, options:).deserialize(source)
       end
     end
 
-    sig { params(serializer_type: Symbol).returns(Typed::Result[T.untyped, Typed::SerializeError]) }
-    def serialize_to(serializer_type)
-      self.class.serializer(serializer_type).serialize(self)
+    sig { params(serializer_type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Result[T.untyped, Typed::SerializeError]) }
+    def serialize_to(serializer_type, options: {})
+      self.class.serializer(serializer_type, options:).serialize(self)
     end
   end
 end

--- a/test/t/struct_test.rb
+++ b/test/t/struct_test.rb
@@ -28,8 +28,8 @@ class StructTest < Minitest::Test
     assert_equal(expected_schema, Job.schema)
   end
 
-  def test_serializer_returns_deeply_nested_hash_serializer
-    serializer = City.serializer(:deeply_nested_hash)
+  def test_serializer_returns_hash_serializer_with_options
+    serializer = City.serializer(:hash, options: {should_serialize_values: true})
 
     assert_kind_of(Typed::HashSerializer, serializer)
     assert(T.cast(serializer, Typed::HashSerializer).should_serialize_values)


### PR DESCRIPTION
After thinking on this for a few days, I think instead of registering a separate _type_ of serialize here, we should set the precedent of being able to pass options to a serializer from here.

I don't love the `unsafe` call here (current limitation of Sorbet), but I think it's a fine trade off in order to be a bit more flexible here. I also am not forwarding options to all serializers by default, and not checking for cases where someone passes options that are invalid for the serializer: we'll just blow up.