### PR TITLE
fix: add sorbet-schema shim for better T:Struct extension compatability

### DIFF
--- a/lib/sorbet-schema/t/struct.rb
+++ b/lib/sorbet-schema/t/struct.rb
@@ -1,18 +1,12 @@
-# typed: strict
+# typed: true
 
 module T
   class Struct
-    extend T::Sig
-
     class << self
-      extend T::Sig
-
-      sig { overridable.returns(Typed::Schema) }
       def schema
         Typed::Schema.from_struct(self)
       end
 
-      sig { params(type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Serializer[T.untyped, T.untyped]) }
       def serializer(type, options: {})
         case type
         when :hash
@@ -24,13 +18,11 @@ module T
         end
       end
 
-      sig { params(serializer_type: Symbol, source: T.untyped, options: T::Hash[Symbol, T.untyped]).returns(Typed::Serializer::DeserializeResult) }
       def deserialize_from(serializer_type, source, options: {})
-        serializer(serializer_type, options:).deserialize(source)
+        T.unsafe(serializer(serializer_type, options:).deserialize(source))
       end
     end
 
-    sig { params(serializer_type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Result[T.untyped, Typed::SerializeError]) }
     def serialize_to(serializer_type, options: {})
       self.class.serializer(serializer_type, options:).serialize(self)
     end

--- a/rbi/sorbet-schema.rbi
+++ b/rbi/sorbet-schema.rbi
@@ -1,0 +1,21 @@
+# typed: strict
+
+class T::Struct
+  class << self
+    sig { overridable.returns(Typed::Schema) }
+    def schema
+    end
+
+    sig { params(type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Serializer[T.untyped, T.untyped]) }
+    def serializer(type, options: {})
+    end
+
+    sig { params(serializer_type: Symbol, source: T.untyped, options: T::Hash[Symbol, T.untyped]).returns(Typed::Result[T.attached_class, Typed::DeserializeError]) }
+    def deserialize_from(serializer_type, source, options: {})
+    end
+  end
+
+  sig { params(serializer_type: Symbol, options: T::Hash[Symbol, T.untyped]).returns(Typed::Result[T.untyped, Typed::SerializeError]) }
+  def serialize_to(serializer_type, options: {})
+  end
+end

--- a/sorbet-schema.gemspec
+++ b/sorbet-schema.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ["lib", "rbi"]
 
   spec.add_runtime_dependency "sorbet-result", "~> 1.1"
   spec.add_runtime_dependency "sorbet-runtime", "~> 0.5"


### PR DESCRIPTION
Closes #87 

There has been issues with the `deserialize_from` method on `T::Struct` in downstream projects where the type had to be cast for the struct. We can use `T.attached_class` for this, however it complicates the type check for the underlying serializers here.

Further, we have an issue of the sigs for the `T::Struct` extension not being [picked up by Tapioca](https://github.com/Shopify/tapioca/issues/1988) and a shim needing to be in place for that.

Instead of adding sigs to the extension, I'm going to try and [export the rbi](https://github.com/Shopify/tapioca?tab=readme-ov-file#importing-hand-written-signatures-from-gems-rbi-folder) as a shim that _should_ be picked up by Tapioca, and use a slightly less safe call in order to give better type information to callers.