### PR TITLE
Fix bug coercing boolean strings

### DIFF
--- a/test/typed/hash_serializer_test.rb
+++ b/test/typed/hash_serializer_test.rb
@@ -109,6 +109,20 @@ class HashSerializerTest < Minitest::Test
     assert_payload(NEW_YORK_CITY, result)
   end
 
+  def test_with_boolean_string_false_it_can_deserialize
+    result = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(City)).deserialize({name: "New York", capital: "false"})
+
+    assert_success(result)
+    assert_payload(NEW_YORK_CITY, result)
+  end
+
+  def test_with_boolean_string_true_it_can_deserialize
+    result = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(City)).deserialize({name: "DC", capital: "true"})
+
+    assert_success(result)
+    assert_payload(DC_CITY, result)
+  end
+
   def test_with_array_it_can_deserialize
     result = Typed::HashSerializer.new(schema: Typed::Schema.from_struct(Country)).deserialize({name: "US", cities: [NEW_YORK_CITY, DC_CITY], national_items: {bird: "bald eagle", anthem: "The Star-Spangled Banner"}})
 

--- a/test/typed/json_serializer_test.rb
+++ b/test/typed/json_serializer_test.rb
@@ -60,6 +60,20 @@ class JSONSerializerTest < Minitest::Test
     assert_payload(NEW_YORK_CITY, result)
   end
 
+  def test_with_boolean_string_false_it_can_deserialize
+    result = Typed::JSONSerializer.new(schema: Typed::Schema.from_struct(City)).deserialize('{"name":"New York","capital":"false"}')
+
+    assert_success(result)
+    assert_payload(NEW_YORK_CITY, result)
+  end
+
+  def test_with_boolean_string_true_it_can_deserialize
+    result = Typed::JSONSerializer.new(schema: Typed::Schema.from_struct(City)).deserialize('{"name":"DC","capital":"true"}')
+
+    assert_success(result)
+    assert_payload(DC_CITY, result)
+  end
+
   def test_with_array_it_can_deep_deserialize
     result = Typed::JSONSerializer.new(schema: Typed::Schema.from_struct(Country)).deserialize('{"name":"US","cities":[{"name":"New York","capital":false},{"name":"DC","capital":true}],"national_items":{"bird":"bald eagle","anthem":"The Star-Spangled Banner"}}')
 


### PR DESCRIPTION
- fields with a type of T::Boolean were getting caught in the T.any conditional block and failing to activate the BooleanCoercer class. I moved the `select_coercer_by` call up to the serializer so we can handle the case where the type alias matches a coercer, falling back to checking each of the individual types in the alias if no top-level coercer is found.