### PR TITLE
perf: Improve coercer performance by using class methods

### DIFF
--- a/lib/typed/coercion/boolean_coercer.rb
+++ b/lib/typed/coercion/boolean_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: T::Boolean} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type == T::Utils.coerce(T::Boolean)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a T::Boolean.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a T::Boolean.")) unless self.class.used_for_type?(type)
 
         if type.recursively_valid?(value)
           Success.new(value)

--- a/lib/typed/coercion/coercer.rb
+++ b/lib/typed/coercion/coercer.rb
@@ -11,7 +11,7 @@ module Typed
       Target = type_member(:out)
 
       sig { abstract.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
       end
 
       sig { abstract.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }

--- a/lib/typed/coercion/coercer_registry.rb
+++ b/lib/typed/coercion/coercer_registry.rb
@@ -45,7 +45,7 @@ module Typed
 
       sig { params(type: T::Types::Base).returns(T.nilable(T.class_of(Coercer))) }
       def select_coercer_by(type:)
-        @available.find { |coercer| coercer.new.used_for_type?(type) }
+        @available.find { |coercer| coercer.used_for_type?(type) }
       end
     end
   end

--- a/lib/typed/coercion/date_coercer.rb
+++ b/lib/typed/coercion/date_coercer.rb
@@ -10,13 +10,13 @@ module Typed
       Target = type_member { {fixed: Date} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         T::Utils.coerce(type) == T::Utils.coerce(Date)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a Date.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a Date.")) unless self.class.used_for_type?(type)
 
         return Success.new(value) if value.is_a?(Date)
 

--- a/lib/typed/coercion/date_time_coercer.rb
+++ b/lib/typed/coercion/date_time_coercer.rb
@@ -10,13 +10,13 @@ module Typed
       Target = type_member { {fixed: DateTime} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         T::Utils.coerce(type) == T::Utils.coerce(DateTime)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a DateTime.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a DateTime.")) unless self.class.used_for_type?(type)
 
         return Success.new(value) if value.is_a?(DateTime)
 

--- a/lib/typed/coercion/enum_coercer.rb
+++ b/lib/typed/coercion/enum_coercer.rb
@@ -8,7 +8,7 @@ module Typed
       Target = type_member { {fixed: T::Enum} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         return false unless type.respond_to?(:raw_type)
 
         !!(T.cast(type, T::Types::Simple).raw_type < T::Enum)
@@ -16,7 +16,7 @@ module Typed
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Field type must inherit from T::Enum for Enum coercion.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Field type must inherit from T::Enum for Enum coercion.")) unless self.class.used_for_type?(type)
 
         Success.new(T.cast(type, T::Types::Simple).raw_type.from_serialized(value))
       rescue KeyError => e

--- a/lib/typed/coercion/float_coercer.rb
+++ b/lib/typed/coercion/float_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: Float} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         T::Utils.coerce(type) == T::Utils.coerce(Float)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a Float.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a Float.")) unless self.class.used_for_type?(type)
 
         Success.new(Float(value))
       rescue ArgumentError, TypeError

--- a/lib/typed/coercion/integer_coercer.rb
+++ b/lib/typed/coercion/integer_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: Integer} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type == T::Utils.coerce(Integer)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a Integer.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a Integer.")) unless self.class.used_for_type?(type)
 
         Success.new(Integer(value))
       rescue ArgumentError, TypeError

--- a/lib/typed/coercion/string_coercer.rb
+++ b/lib/typed/coercion/string_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: String} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type == T::Utils.coerce(String)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a String.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a String.")) unless self.class.used_for_type?(type)
 
         Success.new(String(value))
       end

--- a/lib/typed/coercion/struct_coercer.rb
+++ b/lib/typed/coercion/struct_coercer.rb
@@ -8,7 +8,7 @@ module Typed
       Target = type_member { {fixed: T::Struct} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         return false unless type.respond_to?(:raw_type)
 
         !!(T.cast(type, T::Types::Simple).raw_type < T::Struct)
@@ -16,7 +16,7 @@ module Typed
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Field type must inherit from T::Struct for Struct coercion.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Field type must inherit from T::Struct for Struct coercion.")) unless self.class.used_for_type?(type)
         return Success.new(value) if type.recursively_valid?(value)
 
         return Failure.new(CoercionError.new("Value of type '#{value.class}' cannot be coerced to #{type} Struct.")) unless value.is_a?(Hash)

--- a/lib/typed/coercion/symbol_coercer.rb
+++ b/lib/typed/coercion/symbol_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: Symbol} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type == T::Utils.coerce(Symbol)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Type must be a Symbol.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Type must be a Symbol.")) unless self.class.used_for_type?(type)
 
         if value.respond_to?(:to_sym)
           Success.new(value.to_sym)

--- a/lib/typed/coercion/typed_array_coercer.rb
+++ b/lib/typed/coercion/typed_array_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: T::Array[T.untyped]} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type.is_a?(T::Types::TypedArray)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Field type must be a T::Array.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Field type must be a T::Array.")) unless self.class.used_for_type?(type)
         return Failure.new(CoercionError.new("Value must be an Array.")) unless value.is_a?(Array)
 
         return Success.new(value) if type.recursively_valid?(value)

--- a/lib/typed/coercion/typed_hash_coercer.rb
+++ b/lib/typed/coercion/typed_hash_coercer.rb
@@ -8,13 +8,13 @@ module Typed
       Target = type_member { {fixed: T::Hash[T.untyped, T.untyped]} }
 
       sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-      def used_for_type?(type)
+      def self.used_for_type?(type)
         type.is_a?(T::Types::TypedHash)
       end
 
       sig { override.params(type: T::Types::Base, value: Value).returns(Result[Target, CoercionError]) }
       def coerce(type:, value:)
-        return Failure.new(CoercionError.new("Field type must be a T::Hash.")) unless used_for_type?(type)
+        return Failure.new(CoercionError.new("Field type must be a T::Hash.")) unless self.class.used_for_type?(type)
         return Failure.new(CoercionError.new("Value must be a Hash.")) unless value.is_a?(Hash)
 
         return Success.new(value) if type.recursively_valid?(value)

--- a/test/support/simple_string_coercer.rb
+++ b/test/support/simple_string_coercer.rb
@@ -6,7 +6,7 @@ class SimpleStringCoercer < Typed::Coercion::Coercer
   Target = type_member { {fixed: String} }
 
   sig { override.params(type: T::Types::Base).returns(T::Boolean) }
-  def used_for_type?(type)
+  def self.used_for_type?(type)
     type == T::Utils.coerce(String)
   end
 

--- a/test/typed/coercion/boolean_coercer_test.rb
+++ b/test/typed/coercion/boolean_coercer_test.rb
@@ -7,8 +7,8 @@ class BooleanCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_boolean_type_given_returns_failure

--- a/test/typed/coercion/coercer_registry_test.rb
+++ b/test/typed/coercion/coercer_registry_test.rb
@@ -13,7 +13,7 @@ class CoercerRegistryTest < Minitest::Test
     assert_equal(SimpleStringCoercer, Typed::Coercion::CoercerRegistry.instance.select_coercer_by(type: T::Utils.coerce(String)))
   end
 
-  def test_when_type_doesnt_match_coercer_returns_nil
+  def test_when_type_does_not_match_coercer_returns_nil
     assert_nil(Typed::Coercion::CoercerRegistry.instance.select_coercer_by(type: T::Utils.coerce(BigDecimal)))
   end
 end

--- a/test/typed/coercion/date_coercer_test.rb
+++ b/test/typed/coercion/date_coercer_test.rb
@@ -9,8 +9,8 @@ class DateCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_date_type_given_returns_failure

--- a/test/typed/coercion/date_time_coercer_test.rb
+++ b/test/typed/coercion/date_time_coercer_test.rb
@@ -9,8 +9,8 @@ class DateTimeCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_date_type_given_returns_failure

--- a/test/typed/coercion/enum_coercer_test.rb
+++ b/test/typed/coercion/enum_coercer_test.rb
@@ -6,9 +6,9 @@ class EnumCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(T::Utils.coerce(RubyRank)))
-    refute(@coercer.used_for_type?(T::Utils.coerce(T::Enum)))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(RubyRank)))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(T::Enum)))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_enum_field_given_returns_failure

--- a/test/typed/coercion/float_coercer_test.rb
+++ b/test/typed/coercion/float_coercer_test.rb
@@ -7,8 +7,8 @@ class FloatCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_float_type_given_returns_failure

--- a/test/typed/coercion/integer_coercer_test.rb
+++ b/test/typed/coercion/integer_coercer_test.rb
@@ -7,8 +7,8 @@ class IntegerCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Float)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Float)))
   end
 
   def test_when_non_integer_type_given_returns_failure

--- a/test/typed/coercion/string_coercer_test.rb
+++ b/test/typed/coercion/string_coercer_test.rb
@@ -7,8 +7,8 @@ class StringCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_string_type_given_returns_failure

--- a/test/typed/coercion/struct_coercer_test.rb
+++ b/test/typed/coercion/struct_coercer_test.rb
@@ -8,9 +8,9 @@ class StructCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(T::Struct)))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(T::Struct)))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_struct_type_given_returns_failure

--- a/test/typed/coercion/symbol_coercer_test.rb
+++ b/test/typed/coercion/symbol_coercer_test.rb
@@ -7,8 +7,8 @@ class SymbolCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(@type))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(@type))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_symbol_type_given_returns_failure

--- a/test/typed/coercion/typed_array_coercer_test.rb
+++ b/test/typed/coercion/typed_array_coercer_test.rb
@@ -7,10 +7,10 @@ class TypedArrayCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(T::Utils.coerce(T::Array[City])))
-    assert(@coercer.used_for_type?(T::Utils.coerce(T::Array[String])))
-    assert(@coercer.used_for_type?(T::Utils.coerce(Array)))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(T::Array[City])))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(T::Array[String])))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(Array)))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_array_field_given_returns_failure

--- a/test/typed/coercion/typed_hash_coercer_test.rb
+++ b/test/typed/coercion/typed_hash_coercer_test.rb
@@ -9,10 +9,10 @@ class TypedHashCoercerTest < Minitest::Test
   end
 
   def test_used_for_type_works
-    assert(@coercer.used_for_type?(T::Utils.coerce(T::Hash[String, Integer])))
-    assert(@coercer.used_for_type?(T::Utils.coerce(T::Hash[String, String])))
-    assert(@coercer.used_for_type?(T::Utils.coerce(Hash)))
-    refute(@coercer.used_for_type?(T::Utils.coerce(Integer)))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(T::Hash[String, Integer])))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(T::Hash[String, String])))
+    assert(@coercer.class.used_for_type?(T::Utils.coerce(Hash)))
+    refute(@coercer.class.used_for_type?(T::Utils.coerce(Integer)))
   end
 
   def test_when_non_hash_field_given_returns_failure


### PR DESCRIPTION
Relates to https://github.com/maxveldink/sorbet-schema/issues/133

This commit improves the performance of the type coercion process by changing the  method in the  class to be a
class method. This avoids unnecessary object allocations when checking if a coercer can be used for a given type.

- Change  to a class method in  and all subclasses
- Update  to use the new class method
- Add a benchmark to measure the performance of the coercion process

cc @jays306 - I'm not sure what happened to your PR? I was resurrecting this 