### PR TITLE
perf: caching for serializers and coercers

### DIFF
--- a/benchmarks/many_fields_coercion.rb
+++ b/benchmarks/many_fields_coercion.rb
@@ -1,0 +1,167 @@
+# typed: strict
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "benchmark/ips"
+require "sorbet-schema"
+
+# Define a struct with MANY fields of the same types that require coercion
+# This will stress-test coercer caching by reusing the same coercers many times
+class LargeStruct < T::Struct
+  # Many Integer fields that will come in as strings
+  const :field_1, Integer
+  const :field_2, Integer
+  const :field_3, Integer
+  const :field_4, Integer
+  const :field_5, Integer
+  const :field_6, Integer
+  const :field_7, Integer
+  const :field_8, Integer
+  const :field_9, Integer
+  const :field_10, Integer
+  const :field_11, Integer
+  const :field_12, Integer
+  const :field_13, Integer
+  const :field_14, Integer
+  const :field_15, Integer
+  const :field_16, Integer
+  const :field_17, Integer
+  const :field_18, Integer
+  const :field_19, Integer
+  const :field_20, Integer
+  const :field_21, Integer
+  const :field_22, Integer
+  const :field_23, Integer
+  const :field_24, Integer
+  const :field_25, Integer
+  const :field_26, Integer
+  const :field_27, Integer
+  const :field_28, Integer
+  const :field_29, Integer
+  const :field_30, Integer
+  const :field_31, Integer
+  const :field_32, Integer
+  const :field_33, Integer
+  const :field_34, Integer
+  const :field_35, Integer
+  const :field_36, Integer
+  const :field_37, Integer
+  const :field_38, Integer
+  const :field_39, Integer
+  const :field_40, Integer
+  const :field_41, Integer
+  const :field_42, Integer
+  const :field_43, Integer
+  const :field_44, Integer
+  const :field_45, Integer
+  const :field_46, Integer
+  const :field_47, Integer
+  const :field_48, Integer
+  const :field_49, Integer
+  const :field_50, Integer
+
+  # Many Float fields that will come in as strings
+  const :float_1, Float
+  const :float_2, Float
+  const :float_3, Float
+  const :float_4, Float
+  const :float_5, Float
+  const :float_6, Float
+  const :float_7, Float
+  const :float_8, Float
+  const :float_9, Float
+  const :float_10, Float
+  const :float_11, Float
+  const :float_12, Float
+  const :float_13, Float
+  const :float_14, Float
+  const :float_15, Float
+  const :float_16, Float
+  const :float_17, Float
+  const :float_18, Float
+  const :float_19, Float
+  const :float_20, Float
+
+  # Many Boolean fields that will come in as strings
+  const :bool_1, T::Boolean
+  const :bool_2, T::Boolean
+  const :bool_3, T::Boolean
+  const :bool_4, T::Boolean
+  const :bool_5, T::Boolean
+  const :bool_6, T::Boolean
+  const :bool_7, T::Boolean
+  const :bool_8, T::Boolean
+  const :bool_9, T::Boolean
+  const :bool_10, T::Boolean
+  const :bool_11, T::Boolean
+  const :bool_12, T::Boolean
+  const :bool_13, T::Boolean
+  const :bool_14, T::Boolean
+  const :bool_15, T::Boolean
+  const :bool_16, T::Boolean
+  const :bool_17, T::Boolean
+  const :bool_18, T::Boolean
+  const :bool_19, T::Boolean
+  const :bool_20, T::Boolean
+
+  # Many Symbol fields that will come in as strings
+  const :sym_1, Symbol
+  const :sym_2, Symbol
+  const :sym_3, Symbol
+  const :sym_4, Symbol
+  const :sym_5, Symbol
+  const :sym_6, Symbol
+  const :sym_7, Symbol
+  const :sym_8, Symbol
+  const :sym_9, Symbol
+  const :sym_10, Symbol
+  const :sym_11, Symbol
+  const :sym_12, Symbol
+  const :sym_13, Symbol
+  const :sym_14, Symbol
+  const :sym_15, Symbol
+  const :sym_16, Symbol
+  const :sym_17, Symbol
+  const :sym_18, Symbol
+  const :sym_19, Symbol
+  const :sym_20, Symbol
+end
+
+# Create a schema for the LargeStruct
+large_schema = Typed::Schema.from_struct(LargeStruct)
+
+# Generate data with strings that need to be coerced to the target types
+large_data = {
+  field_1: "1", field_2: "2", field_3: "3", field_4: "4", field_5: "5",
+  field_6: "6", field_7: "7", field_8: "8", field_9: "9", field_10: "10",
+  field_11: "11", field_12: "12", field_13: "13", field_14: "14", field_15: "15",
+  field_16: "16", field_17: "17", field_18: "18", field_19: "19", field_20: "20",
+  field_21: "21", field_22: "22", field_23: "23", field_24: "24", field_25: "25",
+  field_26: "26", field_27: "27", field_28: "28", field_29: "29", field_30: "30",
+  field_31: "31", field_32: "32", field_33: "33", field_34: "34", field_35: "35",
+  field_36: "36", field_37: "37", field_38: "38", field_39: "39", field_40: "40",
+  field_41: "41", field_42: "42", field_43: "43", field_44: "44", field_45: "45",
+  field_46: "46", field_47: "47", field_48: "48", field_49: "49", field_50: "50",
+  float_1: "1.1", float_2: "2.2", float_3: "3.3", float_4: "4.4", float_5: "5.5",
+  float_6: "6.6", float_7: "7.7", float_8: "8.8", float_9: "9.9", float_10: "10.1",
+  float_11: "11.1", float_12: "12.2", float_13: "13.3", float_14: "14.4", float_15: "15.5",
+  float_16: "16.6", float_17: "17.7", float_18: "18.8", float_19: "19.9", float_20: "20.1",
+  bool_1: "true", bool_2: "false", bool_3: "true", bool_4: "false", bool_5: "true",
+  bool_6: "false", bool_7: "true", bool_8: "false", bool_9: "true", bool_10: "false",
+  bool_11: "true", bool_12: "false", bool_13: "true", bool_14: "false", bool_15: "true",
+  bool_16: "false", bool_17: "true", bool_18: "false", bool_19: "true", bool_20: "false",
+  sym_1: "sym1", sym_2: "sym2", sym_3: "sym3", sym_4: "sym4", sym_5: "sym5",
+  sym_6: "sym6", sym_7: "sym7", sym_8: "sym8", sym_9: "sym9", sym_10: "sym10",
+  sym_11: "sym11", sym_12: "sym12", sym_13: "sym13", sym_14: "sym14", sym_15: "sym15",
+  sym_16: "sym16", sym_17: "sym17", sym_18: "sym18", sym_19: "sym19", sym_20: "sym20"
+}
+
+# Run the benchmark
+Benchmark.ips do |x|
+  x.report("hash deserialization with many fields") do
+    large_schema.from_hash(large_data)
+  end
+
+  x.compare!
+end

--- a/benchmarks/simple_coercion.rb
+++ b/benchmarks/simple_coercion.rb
@@ -91,7 +91,7 @@ game_data = {
 
 # Run the benchmark
 Benchmark.ips do |x|
-  x.report("deserialization") do
+  x.report("simple hash deserialization") do
     game_schema.from_hash(game_data)
   end
 

--- a/lib/typed/schema.rb
+++ b/lib/typed/schema.rb
@@ -20,12 +20,12 @@ module Typed
 
     sig { params(hash: Typed::HashSerializer::InputHash).returns(Typed::Serializer::DeserializeResult) }
     def from_hash(hash)
-      Typed::HashSerializer.new(schema: self).deserialize(hash)
+      hash_serializer.deserialize(hash)
     end
 
     sig { params(json: String).returns(Typed::Serializer::DeserializeResult) }
     def from_json(json)
-      Typed::JSONSerializer.new(schema: self).deserialize(json)
+      json_serializer.deserialize(json)
     end
 
     sig { params(field_name: Symbol, serializer: Field::InlineSerializer).returns(Schema) }
@@ -40,6 +40,20 @@ module Typed
           end
         end
       )
+    end
+
+    private
+
+    sig { returns(Typed::HashSerializer) }
+    def hash_serializer
+      @hash_serializer = T.let(@hash_serializer, T.nilable(Typed::HashSerializer))
+      @hash_serializer ||= Typed::HashSerializer.new(schema: self)
+    end
+
+    sig { returns(Typed::JSONSerializer) }
+    def json_serializer
+      @json_serializer = T.let(@json_serializer, T.nilable(Typed::JSONSerializer))
+      @json_serializer ||= Typed::JSONSerializer.new(schema: self)
     end
   end
 end

--- a/lib/typed/serializer.rb
+++ b/lib/typed/serializer.rb
@@ -15,9 +15,13 @@ module Typed
     sig { returns(Schema) }
     attr_reader :schema
 
+    sig { returns(T::Hash[T::Types::Base, T.untyped]) }
+    attr_reader :coercer_cache
+
     sig { params(schema: Schema).void }
     def initialize(schema:)
       @schema = schema
+      @coercer_cache = T.let({}, T::Hash[T::Types::Base, T.untyped])
     end
 
     sig { abstract.params(source: Input).returns(DeserializeResult) }
@@ -34,41 +38,43 @@ module Typed
     def deserialize_from_creation_params(creation_params)
       results = schema.fields.map do |field|
         value = creation_params.fetch(field.name, nil)
-        coercer = Coercion::CoercerRegistry.instance.select_coercer_by(type: field.type)
 
         if value.nil? && !field.default.nil?
           Success.new(Validations::ValidatedValue.new(name: field.name, value: field.default))
         elsif value.nil? || field.works_with?(value)
           field.validate(value)
-        elsif !coercer.nil?
-          result = coercer.new.coerce(type: field.type, value:)
-          if result.success?
-            field.validate(result.payload)
-          else
-            Failure.new(Validations::ValidationError.new(result.error.message))
-          end
-        elsif field.type.class <= T::Types::Union
-          errors = []
-          validated_value = T.let(nil, T.nilable(Typed::Result[Typed::Validations::ValidatedValue, Typed::Validations::ValidationError]))
-
-          T.cast(field.type, T::Types::Union).types.each do |sub_type|
-            # the if clause took care of cases where value is nil so we can skip NilClass
-            next if sub_type.raw_type.equal?(NilClass)
-
-            coercion_result = Coercion.coerce(type: sub_type, value: value)
-
-            if coercion_result.success?
-              validated_value = field.validate(coercion_result.payload)
-
-              break
-            else
-              errors << Validations::ValidationError.new(coercion_result.error.message)
-            end
-          end
-
-          validated_value.nil? ? Failure.new(Validations::ValidationError.new(errors.map(&:message).join(", "))) : validated_value
         else
-          Failure.new(Validations::ValidationError.new("Coercer not found for type #{field.type}."))
+          coercer_instance = fetch_coercer(field.type)
+          if !coercer_instance.nil?
+            result = coercer_instance.coerce(type: field.type, value:)
+            if result.success?
+              field.validate(result.payload)
+            else
+              Failure.new(Validations::ValidationError.new(result.error.message))
+            end
+          elsif field.type.class <= T::Types::Union
+            errors = []
+            validated_value = T.let(nil, T.nilable(Typed::Result[Typed::Validations::ValidatedValue, Typed::Validations::ValidationError]))
+
+            T.cast(field.type, T::Types::Union).types.each do |sub_type|
+              # the if clause took care of cases where value is nil so we can skip NilClass
+              next if sub_type.raw_type.equal?(NilClass)
+
+              coercion_result = Coercion.coerce(type: sub_type, value: value)
+
+              if coercion_result.success?
+                validated_value = field.validate(coercion_result.payload)
+
+                break
+              else
+                errors << Validations::ValidationError.new(coercion_result.error.message)
+              end
+            end
+
+            validated_value.nil? ? Failure.new(Validations::ValidationError.new(errors.map(&:message).join(", "))) : validated_value
+          else
+            Failure.new(Validations::ValidationError.new("Coercer not found for type #{field.type}."))
+          end
         end
       end
 
@@ -89,6 +95,17 @@ module Typed
       end
 
       hsh
+    end
+
+    sig { params(type: T::Types::Base).returns(T.untyped) }
+    def fetch_coercer(type)
+      cached = coercer_cache[type]
+      return cached if cached
+
+      coercer_class = Coercion::CoercerRegistry.instance.select_coercer_by(type: type)
+      return nil if coercer_class.nil?
+
+      coercer_cache[type] = coercer_class.new
     end
   end
 end


### PR DESCRIPTION
Relates to #133 

- Introduced serializer cache in `schema.rb`
- Introduced a coercer cache in `Typed::Serializer` to store coercer instances, reducing registry lookups and object allocations during deserialization.
- New benchmark for large schemas with many fields of the same type.

These changes drastically speed up performance on large schemas with many fields of the same type (large API payloads, CSV imports, etc)
<img width="1167" height="595" alt="Screenshot 2025-11-09 at 4 45 54 PM" src="https://github.com/user-attachments/assets/8db17c0c-bd7f-4efc-b7fa-fbaa1aea76ab" />

We actually take a slight performance hit on the simpler deserialization.
<img width="1137" height="550" alt="Screenshot 2025-11-09 at 4 48 09 PM" src="https://github.com/user-attachments/assets/3e18d199-02f5-4908-8b10-4311668bd7c3" />

Since the speed up on large schemas is so pronounced, I'm going to opt to pull this change in